### PR TITLE
Update Dockerfile for Ren'Py 7.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update
-RUN apt-get install --yes bzip2 wget
+RUN apt-get install --yes bzip2 wget libxext6 libllvm6.0 mesa-utils
 
 COPY build.sh /build.sh
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This GitHub action allows you to make distributable builds of a Ren'Py visual no
 
 - `project-dir`: The directory where the project exists. Will default to `'.'` (root) if none is found.
 
+> :warning: If you are targeting Ren'Py v7.4.0+, you must use v1.1.2 of this action or greater.
+
 ### Outputs
 
 - `dir`: The directory where the files were built to.


### PR DESCRIPTION
Ren'Py 7.4 introduced some new system requirements and the Dockerfile needed to be updated to keep track of the dependencies needed.

The Dockerfile now installs the following:

- `mesa-utils` (for OpenGL)
- `libx11-6`
- `libxext6`
- `libllvm-6.0`