### PR TITLE
Add empty old-game directory checks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,9 @@ if [ -d "$2/old-game" ]; then
     echo "old-game directory detected."
     if [ -z "$(ls -A "$2/old-game")" ]; then
         echo "ERROR: old-game is empty. This will cause incompatibility issues."
-        echo "Please refer to the Ren'Py documentation on the old-game directory"
-        echo "for more information."
+        echo "For more information on how the old-game directory works and why"
+        echo "this directory should not be empty, please refer to the documentation"
+        echo "at: https://www.renpy.org/doc/html/build.html#old-game."
         exit 1
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,18 @@ tar -xf ./${sdk_name}.tar.bz2
 rm ./${sdk_name}.tar.bz2
 mv ./${sdk_name} ../renpy
 
+# Note: This will be checked regardless of the version of Ren'Py. Caution is
+# advised.
+if [ -d "$2/old-game" ]; then
+    echo "old-game directory detected."
+    if [ -z "$(ls -A "$2/old-game")" ]; then
+        echo "ERROR: old-game is empty. This will cause incompatibility issues."
+        echo "Please refer to the Ren'Py documentation on the old-game directory"
+        echo "for more information."
+        exit 1
+    fi
+fi
+
 echo "Building the project at $2..."
 if ../renpy/renpy.sh ../renpy/launcher distribute $2; then
     built_dir=$(ls | grep '\-dists')


### PR DESCRIPTION
In newer versions of Ren'Py, the old-game directory was introduced. Per a suggestion (#5), this commit adds a check to verify that, if the old-game dir exists, that it isn't empty. If it is, the script exits with return code 1, which should trigger GitHub Actions to treat the workflow as a failed run.

This issue fixes #5.