### PR TITLE
feat: add package input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ This GitHub action allows you to make distributable builds of a Ren'Py visual no
 
 > :warning: If you are targeting Ren'Py v7.4.0+, you must use v1.1.2 of this action or greater.
 
+**Optional Parameters:**
+
+- `package`: Specific package to build for. Must be one of the following: `pc`, `mac`, `linux`, `market`, `web`, `android`. Will build for all packages if value is not supported.
+
 ### Outputs
 
 - `dir`: The directory where the files were built to.

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,17 @@ inputs:
     description: "The path to the directory where the project exists"
     required: true
     default: '.'
+  package:
+    description: "Specific package to build for"
+    required: false
+    type: choice
+    options:
+      - pc
+      - mac
+      - linux
+      - market
+      - web
+      - android
 outputs:
   dir:
     description: "The directory where the distributed files exist"
@@ -21,6 +32,7 @@ runs:
   args:
     - ${{ inputs.sdk-version }}
     - ${{ inputs.project-dir }}
+    - ${{ inputs.package }}
 branding:
   color: 'gray-dark'
   icon: 'archive'

--- a/build.sh
+++ b/build.sh
@@ -24,8 +24,17 @@ if [ -d "$2/old-game" ]; then
     fi
 fi
 
+case $3 in
+    pc|mac|linux|market|web|android)
+        COMMAND="../renpy/renpy.sh ../renpy/launcher distribute --package $3 $2"
+        ;;
+    *)
+        COMMAND="../renpy/renpy.sh ../renpy/launcher distribute $2"
+        ;;
+esac
+
 echo "Building the project at $2..."
-if ../renpy/renpy.sh ../renpy/launcher distribute $2; then
+if $COMMAND; then
     built_dir=$(ls | grep '\-dists')
     echo ::set-output name=dir::$built_dir
     echo ::set-output name=version::${built_dir%'-dists'}


### PR DESCRIPTION
Allow selecting a specific package to build using `package` input instead of always building all packages. Useful for decreasing action minutes.