### PR TITLE
feat(params): option to add steam lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update
-RUN apt-get install --yes bzip2 wget libxext6 libllvm6.0 mesa-utils
+RUN apt-get install --yes bzip2 wget libxext6 libllvm6.0 mesa-utils unzip rsync
 
 COPY build.sh /build.sh
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This GitHub action allows you to make distributable builds of a Ren'Py visual no
 
 - `package`: Specific package to build for. Must be one of the following: `pc`, `mac`, `linux`, `market`, `web`, `android`. Will build for all packages if value is not supported.
 
+- `add-steam-lib`: Whether to include Steam lib. This is necessary if you want your build to work with Steam achievements. Defaults to `false`.
+
 ### Outputs
 
 - `dir`: The directory where the files were built to.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
       - market
       - web
       - android
+  add-steam-lib:
+    description: "Whether to include Steam lib"
+    required: false
+    default: false
+    type: boolean
 outputs:
   dir:
     description: "The directory where the distributed files exist"
@@ -33,6 +38,7 @@ runs:
     - ${{ inputs.sdk-version }}
     - ${{ inputs.project-dir }}
     - ${{ inputs.package }}
+    - ${{ inputs.add-steam-lib }}
 branding:
   color: 'gray-dark'
   icon: 'archive'

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,19 @@ tar -xf ./${sdk_name}.tar.bz2
 rm ./${sdk_name}.tar.bz2
 mv ./${sdk_name} ../renpy
 
+if [ $4 = "true" ]; then
+    steam_lib_name=renpy-$1-steam
+    echo "Downloading Steam lib (${steam_lib_name})..."
+    wget -q https://www.renpy.org/dl/$1/${steam_lib_name}.zip
+    clear
+
+    echo "Downloaded Steam lib (${steam_lib_name})..."
+    echo "Adding Steam lib to Renpy"
+    unzip -qq ./${steam_lib_name} -d ${steam_lib_name}
+    rsync -a ${steam_lib_name}/ ../renpy
+    rm -rf ${steam_lib_name} ${steam_lib_name}.zip 
+fi
+
 # Note: This will be checked regardless of the version of Ren'Py. Caution is
 # advised.
 if [ -d "$2/old-game" ]; then


### PR DESCRIPTION
this commit adds an option to download and include the renpy steam library. used for building projects that use steam api such as achievements. the default behaviour is to not include it, same as before this option is added.